### PR TITLE
Reduce docker image size, but Angular image still exceeds 400M

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-dockerImages/golang-https-service.zip filter=lfs diff=lfs merge=lfs -text
-dockerImages/voy_angular_timeis_image_latest.zip filter=lfs diff=lfs merge=lfs -text
+https_service-angular-service.tar filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@ git lfs clone https://github.com/fafalina/https_service.git
 ```
 
 # Docker Images
-Please unzip golang-https-service.zip and voy_angular_timeis_image_latest.zip in /dockerImages and run the following commands.
+Please load docker images or use 'docker compose up'.
 ```bash
-docker load -i golang-https-service.tar
-docker load -i voy_angular_timeis_image_latest.tar
+docker load -i https_service-golang-service.tar
+docker load -i https_service-angular-service.tar
 
-docker run -p 8080:8080 voy/golang-https-service
-docker run -p 4200:4200 voy/angular-timeis-image
+docker run -p 8080:8080 https_service-golang-service.tar
+docker run -p 4200:4200 https_service-angular-service.tar
+```
+
+```bash
+docker compose up
 ```
 
 # Record Some Methods Here

--- a/dockerImages/golang-https-service.zip
+++ b/dockerImages/golang-https-service.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99bd24036dd2c3da6c7d35d5a6e872805c721a27772ab85b908f8aa80deb0ece
-size 489758840

--- a/dockerImages/https_service-angular-service.tar
+++ b/dockerImages/https_service-angular-service.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8199751041b25aa41cdc6e67425b022a0468b8d27e60df9804dc331ed4a731a
+size 455202816

--- a/dockerImages/voy_angular_timeis_image_latest.zip
+++ b/dockerImages/voy_angular_timeis_image_latest.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ffbfa37cf40b1a66c240d9dca3329eda8a221b801826195c2cc582668141b26
-size 481528527


### PR DESCRIPTION
Reduce docker image size, but Angular image still exceeds 400M